### PR TITLE
プレイヤー周りの追加（プレイヤーの作成、弾の生成・制御を追加）

### DIFF
--- a/Assets/Datas/BulletDataSO.asset
+++ b/Assets/Datas/BulletDataSO.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5aa1e46273695af4281a9518ac3fff02, type: 3}
+  m_Name: BulletDataSO
+  m_EditorClassIdentifier: 
+  bulletDataList:
+  - bulletSpeed: 50
+    bulletPower: 30
+    loadingTime: 5
+    bulletType: 0
+  - bulletSpeed: 0
+    bulletPower: 0
+    loadingTime: 0
+    bulletType: 3
+  - bulletSpeed: 100
+    bulletPower: 10
+    loadingTime: 7
+    bulletType: 1

--- a/Assets/Datas/BulletDataSO.asset.meta
+++ b/Assets/Datas/BulletDataSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 789ea9efb6d5e06439e1e1099cd73b9a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &133552841004135137
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6019502109684960884}
+  - component: {fileID: 9095086325716469071}
+  - component: {fileID: 5965983155416220945}
+  - component: {fileID: 2696877962382506088}
+  - component: {fileID: 6904342896729478510}
+  - component: {fileID: 7767945454978911253}
+  m_Layer: 5
+  m_Name: Bullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6019502109684960884
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133552841004135137}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9095086325716469071
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133552841004135137}
+  m_CullTransparentMesh: 1
+--- !u!114 &5965983155416220945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133552841004135137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!70 &2696877962382506088
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133552841004135137}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 80, y: 1}
+  m_Direction: 0
+--- !u!50 &6904342896729478510
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133552841004135137}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!114 &7767945454978911253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133552841004135137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29bdf1cfa4eb1664c89bd0c9a0002c44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletData: {fileID: 0}

--- a/Assets/Prefabs/Bullet.prefab.meta
+++ b/Assets/Prefabs/Bullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8dd30384b3a3ca54096c7d896acc0549
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -643,6 +643,36 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &975021984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 975021985}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &975021985
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975021984}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.02254033, y: 0.43890166, z: 90}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1414477093
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class Bullet : MonoBehaviour {
+
+    public BulletDataSO.BulletData bulletData;
+
+    public void Shot(BulletDataSO.BulletData bulletData, Vector3 direction) {
+        this.bulletData = bulletData;
+
+        GetComponent<Rigidbody2D>().AddForce(direction * bulletData.bulletSpeed);
+    }
+}

--- a/Assets/Scripts/Bullet.cs.meta
+++ b/Assets/Scripts/Bullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29bdf1cfa4eb1664c89bd0c9a0002c44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BulletDataSO.cs
+++ b/Assets/Scripts/BulletDataSO.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+[CreateAssetMenu(fileName = "BulletDataSO", menuName = "Create BulletDataSO")]
+public class BulletDataSO : ScriptableObject {
+
+    public List<BulletData> bulletDataList = new List<BulletData>();
+
+    [Serializable]
+    public class BulletData {
+        public float bulletSpeed;
+        public int bulletPower;
+        public float loadingTime;
+        public BulletType bulletType;
+    }
+
+    [Serializable]
+    public enum BulletType {
+        A,
+        B,
+        C,
+        None
+    }
+}

--- a/Assets/Scripts/BulletDataSO.cs.meta
+++ b/Assets/Scripts/BulletDataSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5aa1e46273695af4281a9518ac3fff02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    public Bullet bulletPrefab;
+
+    public BulletDataSO.BulletData bulletData;
+
+    void Start()
+    {
+
+    }
+
+
+    void Update() {
+        if (Input.GetMouseButtonDown(0)) {
+            Vector3 tapPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+
+            tapPos.z = 2.0f;
+
+            Vector3 direction = (tapPos - transform.position).normalized;
+                    
+            Instantiate(bulletPrefab, transform).Shot(bulletData, direction);
+        }    
+    }
+}

--- a/Assets/Scripts/PlayerController.cs.meta
+++ b/Assets/Scripts/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4af523be0e5e90a4e8afa3c1da43808f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・プレイヤー用ゲームオブジェクトを作成。
・PlayerController.cs作成。プレイヤーと弾の生成を制御。
・弾用のゲームオブジェクトを作成。
・Bullet.cs作成。弾の移動を制御。
・BulletDataSO.cs作成。スクリタブル・オブジェクトに弾の情報を登録して運用。
・画面をタップすると、その方向に向けて弾を生成して発射する制御を追加。
・タップ位置で弾の速度が変わらないように制御。
・デバッグ完了。