### PR TITLE
エネミー生成時にスクリプタブル・オブジェクトよりデータを取得制御

### DIFF
--- a/Assets/Datas/EnemyDataSO.asset
+++ b/Assets/Datas/EnemyDataSO.asset
@@ -13,11 +13,15 @@ MonoBehaviour:
   m_Name: EnemyDataSO
   m_EditorClassIdentifier: 
   enemyDataList:
-  - enemyType: 0
-    hp: 20
+  - no: 0
+    enemyType: 0
+    hp: 50
     power: 20
     bulletType: 1
-  - enemyType: 1
-    hp: 300
-    power: 50
+    enemySprite: {fileID: 21300000, guid: ec1fba5bf7d73eb479eeeff2e4e164ad, type: 3}
+  - no: 1
+    enemyType: 1
+    hp: 30
+    power: 30
     bulletType: 3
+    enemySprite: {fileID: 21300000, guid: a177e9738fb88644fafed7066b2a19d6, type: 3}

--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -74,7 +74,9 @@ MonoBehaviour:
     hp: 50
     power: 0
     bulletType: 0
+    enemySprite: {fileID: 0}
   playerController: {fileID: 0}
+  imgEnemy: {fileID: 4725010894336348469}
   slider: {fileID: 4985900750795913563}
   canvasGroupSlider: {fileID: 4985900750795913564}
   floatingDamageTran: {fileID: 1820453695654612428}
@@ -144,7 +146,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: ec1fba5bf7d73eb479eeeff2e4e164ad, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 37d93363eac1c5744bba218836175145, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -507,36 +507,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &320383875
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 320383876}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &320383876
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 320383875}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.073272474, y: -4.3470554, z: 110.95807}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &404833954
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -17,6 +17,9 @@ public class EnemyController : MonoBehaviour
     public PlayerController playerController;
 
     [SerializeField]
+    private Image imgEnemy;
+
+    [SerializeField]
     private Slider slider;
 
     [SerializeField]
@@ -102,8 +105,10 @@ public class EnemyController : MonoBehaviour
         transform.localPosition = new Vector3(transform.localPosition.x + Random.Range(-650, 650), transform.localPosition.y, 0);
 
         this.playerController = playerController;
+
         this.enemyData = enemyData;
-        
+        imgEnemy.sprite = this.enemyData.enemySprite;
+
         if (bulletPrefab != null) {
 
             this.bulletPrefab = bulletPrefab;

--- a/Assets/Scripts/EnemyDataSO.cs
+++ b/Assets/Scripts/EnemyDataSO.cs
@@ -10,16 +10,22 @@ public class EnemyDataSO : ScriptableObject
 
     [Serializable]
     public class EnemyData {
+        public int no;
         public EnemyType enemyType;
         public int hp;
         public int power;
         public BulletDataSO.BulletType bulletType;
+        public Sprite enemySprite; 
     }
 
     [Serializable]
     public enum EnemyType {
-        Normal,
-        Elite,
+        Normal_0,
+        Normal_1,
+        Normal_2,
+        Elite_0,
+        Elite_1,
+        Elite_2,
         Boss
     }
 }

--- a/Assets/Scripts/EnemyGenerator.cs
+++ b/Assets/Scripts/EnemyGenerator.cs
@@ -65,7 +65,8 @@ public class EnemyGenerator : MonoBehaviour
     /// ìGÇÃê∂ê¨
     /// </summary>
     private void GenerateEnemy() {
-        EnemyDataSO.EnemyData enemyData = GetEnemyData(EnemyDataSO.EnemyType.Normal);
+        int randomEnemyNo = Random.Range(0, DataBaseManager.instance.enemyDataSO.enemyDataList.Count);
+        EnemyDataSO.EnemyData enemyData = GetEnemyData((EnemyDataSO.EnemyType)randomEnemyNo);
 
         if (enemyData == null) {
             return;
@@ -109,6 +110,7 @@ public class EnemyGenerator : MonoBehaviour
     /// <param name="enemyType"></param>
     /// <returns></returns>
     private EnemyDataSO.EnemyData GetEnemyData(EnemyDataSO.EnemyType enemyType) {
+        Debug.Log(enemyType);
         foreach (EnemyDataSO.EnemyData enemyData in DataBaseManager.instance.enemyDataSO.enemyDataList.Where(x => x.enemyType == enemyType)) {
             return enemyData;
         }


### PR DESCRIPTION
・エネミー用プレファブ生成時に動的にエネミーの情報をEnemyDataSOより取得して作成する制御を追加。
・移動方法と弾の生成方法もスクリプタブル・オブジェクトよりデータベース化し、エネミーの生成時に自動化処理を追加。
・デバッグ完了。