### PR TITLE
ボス周りの追加(ボスの作成、出現時の演出、破壊処理)

### DIFF
--- a/Assets/Datas/EnemyDataSO.asset
+++ b/Assets/Datas/EnemyDataSO.asset
@@ -21,7 +21,13 @@ MonoBehaviour:
     enemySprite: {fileID: 21300000, guid: ec1fba5bf7d73eb479eeeff2e4e164ad, type: 3}
   - no: 1
     enemyType: 1
-    hp: 30
+    hp: 80
     power: 30
     bulletType: 3
     enemySprite: {fileID: 21300000, guid: a177e9738fb88644fafed7066b2a19d6, type: 3}
+  - no: 2
+    enemyType: 6
+    hp: 200
+    power: 50
+    bulletType: 0
+    enemySprite: {fileID: 21300000, guid: f15219dcb2ea59643bbfc7d5e813dff7, type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -782,6 +782,36 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1245771117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1245771118}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1245771118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245771117}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.022876138, y: -4.39525, z: 137.67488}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1272398802
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -300,6 +300,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 44949136}
   m_CullTransparentMesh: 1
+--- !u!1 &84683265
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 84683266}
+  - component: {fileID: 84683268}
+  - component: {fileID: 84683267}
+  m_Layer: 5
+  m_Name: imgBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &84683266
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84683265}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1152617365}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1500, y: 3000}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &84683267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84683265}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.49411765}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &84683268
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84683265}
+  m_CullTransparentMesh: 1
 --- !u!1 &97355943
 GameObject:
   m_ObjectHideFlags: 0
@@ -499,6 +574,7 @@ RectTransform:
   - {fileID: 1465912267}
   - {fileID: 239567308}
   - {fileID: 1848081266}
+  - {fileID: 1152617365}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -782,6 +858,228 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &914820718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 914820719}
+  - component: {fileID: 914820722}
+  - component: {fileID: 914820721}
+  - component: {fileID: 914820720}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &914820719
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914820718}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1005512533}
+  m_Father: {fileID: 1152617365}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 327.5}
+  m_SizeDelta: {x: 1400, y: 855}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &914820720
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914820718}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &914820721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914820718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 32577f45673603b46b4102785b922615, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &914820722
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 914820718}
+  m_CullTransparentMesh: 1
+--- !u!1 &1005512532
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1005512533}
+  - component: {fileID: 1005512536}
+  - component: {fileID: 1005512535}
+  - component: {fileID: 1005512534}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1005512533
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1005512532}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 914820719}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1000, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1005512534
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1005512532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90d5b3e200849c349aa9814a482b80a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.8113208, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: 10
+  m_nEffectNumber: 20
+  m_UseGraphicAlpha: 1
+--- !u!114 &1005512535
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1005512532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 150
+    m_FontStyle: 3
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 150
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: WARNING!!
+--- !u!222 &1005512536
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1005512532}
+  m_CullTransparentMesh: 1
+--- !u!1 &1152617364
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1152617365}
+  m_Layer: 5
+  m_Name: BossAlertSet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1152617365
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152617364}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 84683266}
+  - {fileID: 914820719}
+  m_Father: {fileID: 313511504}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1245771117
 GameObject:
   m_ObjectHideFlags: 0
@@ -1124,6 +1422,8 @@ MonoBehaviour:
   maxGenerateCount: 4
   isGenerateEnd: 0
   preparateTime: 3
+  isBossDestroyed: 0
+  canvasGroupBossAlert: {fileID: 914820720}
 --- !u!1 &1574221002
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -33,11 +33,17 @@ public class EnemyController : MonoBehaviour
 
     private int maxHp;
 
-    void Start() {
+    private EnemyGenerator enemyGenerator;
+
+    private int hp;
+
+    //void Start() {
         
-        maxHp = enemyData.hp;
-        UpDateDisplayHpGauge();
-    }
+    //    maxHp = enemyData.hp;
+    //    hp = maxHp;
+
+    //    UpDateDisplayHpGauge();
+    //}
 
     void Update() {
         transform.Translate(0, -0.01f, 0);
@@ -60,14 +66,19 @@ public class EnemyController : MonoBehaviour
     /// </summary>
     /// <param name="bullet"></param>
     private void UpdateHp(Bullet bullet) {
-        enemyData.hp -= bullet.bulletData.bulletPower;
-        Debug.Log("Hp : " + enemyData.hp);
+        hp -= bullet.bulletData.bulletPower;
+        Debug.Log("Hp : " + hp);
 
         CreateFloatingDamage(bullet.bulletData.bulletPower);
         UpDateDisplayHpGauge();
 
-        if (enemyData.hp <= 0) {
-            enemyData.hp = 0;
+        if (hp <= 0) {
+            hp = 0;
+
+            if (enemyData.enemyType == EnemyDataSO.EnemyType.Boss) {
+                enemyGenerator.isBossDestroyed = true;
+            }
+
             Destroy(gameObject);
         }
     }
@@ -78,7 +89,7 @@ public class EnemyController : MonoBehaviour
     private void UpDateDisplayHpGauge() {
         Sequence sequence = DOTween.Sequence();
         sequence.Append(canvasGroupSlider.DOFade(1.0f, 0.15f));
-        sequence.Join(slider.DOValue((float)enemyData.hp / maxHp, 0.25f));
+        sequence.Join(slider.DOValue((float)hp / maxHp, 0.25f));
         sequence.AppendInterval(0.25f);
         sequence.Append(canvasGroupSlider.DOFade(0f, 0.15f));
     }
@@ -108,6 +119,11 @@ public class EnemyController : MonoBehaviour
 
         this.enemyData = enemyData;
         imgEnemy.sprite = this.enemyData.enemySprite;
+
+        maxHp = enemyData.hp;
+        hp = maxHp;
+
+        UpDateDisplayHpGauge();
 
         if (bulletPrefab != null) {
 
@@ -142,5 +158,9 @@ public class EnemyController : MonoBehaviour
     /// <returns></returns>
     private Vector3 GetPlayerDirection() {
         return (playerController.transform.position - transform.position).normalized;
+    }
+
+    public void InitializeBoss(EnemyGenerator enemyGenerator) {
+        this.enemyGenerator = enemyGenerator;
     }
 }

--- a/Assets/Scripts/EnemyGenerator.cs
+++ b/Assets/Scripts/EnemyGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using DG.Tweening;
 
 public class EnemyGenerator : MonoBehaviour
 {
@@ -27,6 +28,11 @@ public class EnemyGenerator : MonoBehaviour
     public int preparateTime;
 
     private GameManager gameManager;
+
+    public bool isBossDestroyed;
+
+    [SerializeField]
+    private CanvasGroup canvasGroupBossAlert;
 
     void Start()
     {
@@ -102,6 +108,36 @@ public class EnemyGenerator : MonoBehaviour
             }
         }
         enemyList.Clear();
+    }
+
+    /// <summary>
+    /// É{ÉXê∂ê¨
+    /// </summary>
+    public IEnumerator GenerateBoss() {
+
+        yield return StartCoroutine(DisplayAlert());
+
+        EnemyDataSO.EnemyData enemyData = GetEnemyData(EnemyDataSO.EnemyType.Boss);
+        EnemyController enemy = Instantiate(enemyPrefab, transform);
+        enemy.Inisialize(playerController, GetBulletData(enemyData), enemyData, enemyData.bulletType == BulletDataSO.BulletType.None ? null : bulletPrefab);
+        enemy.InitializeBoss(this);
+        enemyList.Add(enemy);
+
+        generateCount++;
+
+        if (generateCount >= maxGenerateCount) {
+            isGenerateEnd = true;
+            generateCount = 0;
+        }
+    }
+
+    private IEnumerator DisplayAlert() {
+        canvasGroupBossAlert.transform.parent.gameObject.SetActive(true);
+        canvasGroupBossAlert.DOFade(1.0f, 0.5f).SetLoops(6, LoopType.Yoyo);
+        yield return new WaitForSeconds(3.0f);
+        canvasGroupBossAlert.DOFade(0.0f, 0.25f);
+        yield return new WaitForSeconds(0.25f);
+        canvasGroupBossAlert.transform.parent.gameObject.SetActive(false);
     }
 
     /// <summary>

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -18,20 +18,20 @@ public class GameManager : MonoBehaviour
 
     void Start()
     {
-        StartCoroutine(ObsevateGenerateEnemyState());
+        StartCoroutine(ObservateGenerateEnemyState());
     }
 
     /// <summary>
     /// 敵の生成を監視
     /// </summary>
     /// <returns></returns>
-    private IEnumerator ObsevateGenerateEnemyState() {
+    private IEnumerator ObservateGenerateEnemyState() {
         Debug.Log("監視開始");
         bool isAllGenerate = false;
 
         while (!isAllGenerate) {
             if (enemyGenerator.isGenerateEnd) {
-                isAllGenerate =true;
+                isAllGenerate = true;
             }
             yield return null;
         }
@@ -44,6 +44,22 @@ public class GameManager : MonoBehaviour
         }   
     }
 
+    private IEnumerator ObservateBossState() {
+        Debug.Log("ボス監視開始");
+
+        while (!enemyGenerator.isBossDestroyed) {
+            yield return null;
+        }
+
+        Debug.Log("ゲームクリア");
+
+        // エネミーをすべて削除
+        enemyGenerator.ClearEnemyList();
+
+        // クリア表示
+
+    }
+
     /// <summary>
     /// Wave進行
     /// </summary>
@@ -52,12 +68,19 @@ public class GameManager : MonoBehaviour
         Debug.Log(waveCount);
         if (waveCount == maxWaveCount - 1) {
             Debug.Log("Boss");
+
+            // ボス生成
+            StartCoroutine(enemyGenerator.GenerateBoss());
+
+            // ボス監視
+            StartCoroutine(ObservateBossState());
+
         } else {
             // 生成再開
             enemyGenerator.SwitchGenerateState(false);
 
             // 監視再開
-            StartCoroutine(ObsevateGenerateEnemyState());
+            StartCoroutine(ObservateGenerateEnemyState());
         }
     }
 


### PR DESCRIPTION
・条件を満たすとプレファブからボスを生成。データはEnemyDataSOを参照する。
・ボス出現時には警告表示の演出を追加。
・EnemyDataSOの参照方法を変更。HPがデータベースから減らないように修正。
・ボス破壊時、残っているすべてのエネミーも破壊する制御を追加。
・デバッグ完了。