### PR TITLE
弾の選択ボタンを追加。

### DIFF
--- a/Assets/Datas/BulletDataSO.asset
+++ b/Assets/Datas/BulletDataSO.asset
@@ -17,11 +17,41 @@ MonoBehaviour:
     bulletPower: 30
     loadingTime: 5
     bulletType: 0
-  - bulletSpeed: 0
-    bulletPower: 0
-    loadingTime: 0
-    bulletType: 3
+    sprite: {fileID: 21300000, guid: 31d6418afde7f88478c222064f0a3031, type: 3}
+    liberalType: 1
+  - bulletSpeed: 100
+    bulletPower: 20
+    loadingTime: 5
+    bulletType: 7
+    sprite: {fileID: 0}
+    liberalType: 1
   - bulletSpeed: 100
     bulletPower: 10
     loadingTime: 7
     bulletType: 1
+    sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+    liberalType: 1
+  - bulletSpeed: 200
+    bulletPower: 20
+    loadingTime: 7
+    bulletType: 3
+    sprite: {fileID: 21300000, guid: 6fa25de30f19c4542a8eb36e3140fa1f, type: 3}
+    liberalType: 0
+  - bulletSpeed: 100
+    bulletPower: 30
+    loadingTime: 7
+    bulletType: 4
+    sprite: {fileID: 21300000, guid: 0ea79078cf66f134c8e08d5bcd518a49, type: 3}
+    liberalType: 0
+  - bulletSpeed: 300
+    bulletPower: 15
+    loadingTime: 7
+    bulletType: 5
+    sprite: {fileID: 21300000, guid: 37d93363eac1c5744bba218836175145, type: 3}
+    liberalType: 0
+  - bulletSpeed: 500
+    bulletPower: 5
+    loadingTime: 7
+    bulletType: 6
+    sprite: {fileID: 21300000, guid: 2a6d7bf3584512243a1f6a50e15bb283, type: 3}
+    liberalType: 0

--- a/Assets/Datas/EnemyDataSO.asset
+++ b/Assets/Datas/EnemyDataSO.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
     enemyType: 1
     hp: 80
     power: 30
-    bulletType: 3
+    bulletType: 7
     enemySprite: {fileID: 21300000, guid: a177e9738fb88644fafed7066b2a19d6, type: 3}
   - no: 2
     enemyType: 6

--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -132,3 +132,6 @@ MonoBehaviour:
     bulletPower: 0
     loadingTime: 0
     bulletType: 0
+    sprite: {fileID: 0}
+    liberalType: 0
+  imgBullet: {fileID: 5965983155416220945}

--- a/Assets/Prefabs/EnemyBullet.prefab
+++ b/Assets/Prefabs/EnemyBullet.prefab
@@ -132,3 +132,6 @@ MonoBehaviour:
     bulletPower: 0
     loadingTime: 0
     bulletType: 0
+    sprite: {fileID: 0}
+    liberalType: 0
+  imgBullet: {fileID: 5965983155416220945}

--- a/Assets/Prefabs/btnBulletSelect.prefab
+++ b/Assets/Prefabs/btnBulletSelect.prefab
@@ -1,0 +1,224 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4903218183656588931
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5763138691894131344}
+  - component: {fileID: 30811898338347922}
+  - component: {fileID: 500922599897031687}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5763138691894131344
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4903218183656588931}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2818587674053328340}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &30811898338347922
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4903218183656588931}
+  m_CullTransparentMesh: 1
+--- !u!114 &500922599897031687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4903218183656588931}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Button
+--- !u!1 &8776304799050222113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2818587674053328340}
+  - component: {fileID: 8954390186677571333}
+  - component: {fileID: 8929163052580044872}
+  - component: {fileID: 980622975012419831}
+  - component: {fileID: 6478266638016198555}
+  m_Layer: 5
+  m_Name: btnBulletSelect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2818587674053328340
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776304799050222113}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5763138691894131344}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8954390186677571333
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776304799050222113}
+  m_CullTransparentMesh: 1
+--- !u!114 &8929163052580044872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776304799050222113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: e40579d982378d7469bbf2ea1eca7a43, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &980622975012419831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776304799050222113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8929163052580044872}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6478266638016198555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776304799050222113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f96e65ca0d15a4246881131b0a3168ed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  btnBulletSelect: {fileID: 980622975012419831}
+  imgBullet: {fileID: 8929163052580044872}
+  bulletData:
+    bulletSpeed: 0
+    bulletPower: 0
+    loadingTime: 0
+    bulletType: 0
+    sprite: {fileID: 0}
+    liberalType: 0

--- a/Assets/Prefabs/btnBulletSelect.prefab.meta
+++ b/Assets/Prefabs/btnBulletSelect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9be3ffcd2953baa4ba78570fe6b27385
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1080,36 +1080,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1245771117
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1245771118}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1245771118
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1245771117}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.022876138, y: -4.39525, z: 137.67488}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1272398802
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -419,6 +419,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemyGenerator: {fileID: 1465912268}
+  bulletSelectManager: {fileID: 438747826}
+  playerController: {fileID: 239567309}
   isGameUp: 0
   waveCount: 0
   maxWaveCount: 3
@@ -456,7 +458,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -1145}
+  m_AnchoredPosition: {x: 0, y: -730}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &239567309
@@ -476,8 +478,11 @@ MonoBehaviour:
     bulletSpeed: 200
     bulletPower: 30
     loadingTime: 0
-    bulletType: 0
+    bulletType: 3
+    sprite: {fileID: 0}
+    liberalType: 0
   tapCount: 0
+  currentBulletType: 3
 --- !u!1 &313511500
 GameObject:
   m_ObjectHideFlags: 0
@@ -575,6 +580,7 @@ RectTransform:
   - {fileID: 239567308}
   - {fileID: 1848081266}
   - {fileID: 1152617365}
+  - {fileID: 1294049437}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -607,19 +613,19 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 404833954}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1936245073}
   - {fileID: 1824790173}
   - {fileID: 1824503857}
-  m_Father: {fileID: 1986013663}
-  m_RootOrder: 4
+  m_Father: {fileID: 781071329}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -1374.3002}
+  m_AnchoredPosition: {x: 0, y: 101}
   m_SizeDelta: {x: 1400, y: 211.4}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &404833956
@@ -673,6 +679,112 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &438747825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 438747827}
+  - component: {fileID: 438747826}
+  m_Layer: 0
+  m_Name: BulletSelectManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &438747826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 438747825}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9ff59d57faf5e7439ad6bf6fbe0d67e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bulletSelectDetailPrefab: {fileID: 6478266638016198555, guid: 9be3ffcd2953baa4ba78570fe6b27385, type: 3}
+  bulletTran: {fileID: 442035491}
+  bulletSelectDetailList: []
+--- !u!4 &438747827
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 438747825}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &442035490
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 442035491}
+  - component: {fileID: 442035492}
+  m_Layer: 5
+  m_Name: BulletSelectSet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &442035491
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442035490}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1294049437}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 129}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &442035492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442035490}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 250, y: 250}
+  m_Spacing: {x: 50, y: 0}
+  m_Constraint: 1
+  m_ConstraintCount: 4
 --- !u!1 &472701688
 GameObject:
   m_ObjectHideFlags: 0
@@ -858,6 +970,73 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &545473477
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 545473478}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &545473478
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 545473477}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.94101405, y: 0.23275211, z: 90}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &781071328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 781071329}
+  m_Layer: 5
+  m_Name: GaugeSet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &781071329
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 781071328}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 404833955}
+  - {fileID: 2141738110}
+  m_Father: {fileID: 1294049437}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 257}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &914820718
 GameObject:
   m_ObjectHideFlags: 0
@@ -1159,6 +1338,44 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1272398802}
   m_CullTransparentMesh: 1
+--- !u!1 &1294049436
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1294049437}
+  m_Layer: 5
+  m_Name: BottomUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1294049437
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1294049436}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1381847203}
+  - {fileID: 781071329}
+  - {fileID: 442035491}
+  m_Father: {fileID: 313511504}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 50}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1356560989
 GameObject:
   m_ObjectHideFlags: 0
@@ -1233,6 +1450,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1356560989}
+  m_CullTransparentMesh: 1
+--- !u!1 &1381847202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1381847203}
+  - component: {fileID: 1381847205}
+  - component: {fileID: 1381847204}
+  m_Layer: 5
+  m_Name: imgBackground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1381847203
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381847202}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1294049437}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 207.99997}
+  m_SizeDelta: {x: 1500, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1381847204
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381847202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.24528301, g: 0.1957636, b: 0.1957636, a: 0.49411765}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1381847205
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381847202}
   m_CullTransparentMesh: 1
 --- !u!1 &1414477093
 GameObject:
@@ -1581,7 +1873,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.29019642, b: 1, a: 0.5647059}
+  m_Color: {r: 0.47107655, g: 0.39245284, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -2059,14 +2351,12 @@ RectTransform:
   - {fileID: 44949137}
   - {fileID: 472701689}
   - {fileID: 1574221003}
-  - {fileID: 404833955}
-  - {fileID: 2141738110}
   m_Father: {fileID: 313511504}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 395}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!50 &1986013664
@@ -2133,16 +2423,16 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2141738109}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1986013663}
-  m_RootOrder: 5
+  m_Father: {fileID: 781071329}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 5.1501, y: -1374.3}
+  m_AnchoredPosition: {x: 5.1501, y: 155.56506}
   m_SizeDelta: {x: 1410.3, y: 211.4}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2141738111

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -1,15 +1,24 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 [RequireComponent(typeof(Rigidbody2D))]
 public class Bullet : MonoBehaviour {
 
     public BulletDataSO.BulletData bulletData;
 
+    [SerializeField]
+    private Image imgBullet;
+
     public void Shot(BulletDataSO.BulletData bulletData, Vector3 direction) {
         this.bulletData = bulletData;
+        imgBullet.sprite = bulletData.sprite;
 
+        if (bulletData.liberalType == BulletDataSO.LiberalType.Player) {
+            transform.eulerAngles = new Vector3(0, 0, 180);
+            transform.localScale = new Vector3(2, 2, 2);
+        }
         GetComponent<Rigidbody2D>().AddForce(direction * bulletData.bulletSpeed);
     }
 }

--- a/Assets/Scripts/BulletDataSO.cs
+++ b/Assets/Scripts/BulletDataSO.cs
@@ -14,6 +14,8 @@ public class BulletDataSO : ScriptableObject {
         public int bulletPower;
         public float loadingTime;
         public BulletType bulletType;
+        public Sprite sprite;
+        public LiberalType liberalType;
     }
 
     [Serializable]
@@ -21,6 +23,16 @@ public class BulletDataSO : ScriptableObject {
         A,
         B,
         C,
+        D,
+        E,
+        F,
+        G,
         None
+    }
+
+    [Serializable]
+    public enum LiberalType {
+        Player,
+        Enemy
     }
 }

--- a/Assets/Scripts/BulletSelectDetail.cs
+++ b/Assets/Scripts/BulletSelectDetail.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using DG.Tweening;
+
+public class BulletSelectDetail : MonoBehaviour
+{
+    [SerializeField]
+    private Button btnBulletSelect;
+
+    public Image imgBullet;
+
+    public BulletDataSO.BulletData bulletData; // DebugópÇ… public
+
+    private PlayerController playerController;
+
+    private BulletSelectManager bulletSelectManager;
+
+    /// <summary>
+    /// èâä˙ê›íË
+    /// </summary>
+    /// <param name="bulletData"></param>
+    /// <param name="playerController"></param>
+    /// <param name="bulletSelectManager"></param>
+    public void SetUpBulletSelectDetail(BulletDataSO.BulletData bulletData, PlayerController playerController, BulletSelectManager bulletSelectManager) {
+        this.bulletData = bulletData;
+        this.playerController = playerController;
+        this.bulletSelectManager = bulletSelectManager;
+
+        imgBullet.sprite = bulletData.sprite;
+
+        btnBulletSelect.onClick.AddListener(OnClickBulletSelect);
+    }
+
+    /// <summary>
+    /// ëIë
+    /// </summary>
+    private void OnClickBulletSelect() {
+        playerController.ChangeBullet(bulletData.bulletType);
+        bulletSelectManager.ChangeColorToBulletButton(bulletData.bulletType);
+    }
+}

--- a/Assets/Scripts/BulletSelectDetail.cs.meta
+++ b/Assets/Scripts/BulletSelectDetail.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f96e65ca0d15a4246881131b0a3168ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BulletSelectManager.cs
+++ b/Assets/Scripts/BulletSelectManager.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+
+public class BulletSelectManager : MonoBehaviour
+{
+    [SerializeField]
+    private BulletSelectDetail bulletSelectDetailPrefab;
+
+    [SerializeField]
+    private Transform bulletTran;
+
+    public List<BulletSelectDetail> bulletSelectDetailList = new List<BulletSelectDetail>();
+
+    private PlayerController playerController;
+
+    //void Start()
+    //{
+    //    GenerateBulletSelectDetail();
+    //}
+
+    public IEnumerator GenerateBulletSelectDetail(PlayerController playerController) {
+        BulletDataSO.BulletData[] bulletDatas = DataBaseManager.instance.bulletDataSO.bulletDataList.Where((x) => x.liberalType == BulletDataSO.LiberalType.Player).ToArray();
+
+        for (int i = 0; i < bulletDatas.Length; i++) {
+            BulletSelectDetail bulletSelectDetail = Instantiate(bulletSelectDetailPrefab, bulletTran, false);
+            bulletSelectDetail.SetUpBulletSelectDetail(bulletDatas[i], playerController, this);
+            bulletSelectDetailList.Add(bulletSelectDetail);
+            yield return new WaitForSeconds(0.25f);
+        }
+    } 
+
+    /// <summary>
+    /// 選択しているバレットの色を変更
+    /// </summary>
+    /// <param name="bulletType"></param>
+    public void ChangeColorToBulletButton(BulletDataSO.BulletType bulletType) {
+        Debug.Log(bulletType);
+        for (int i = 0; i < bulletSelectDetailList.Count; i++) {
+            if (bulletSelectDetailList[i].bulletData.bulletType == bulletType) {
+
+                // 選択中は灰色
+                bulletSelectDetailList[i].imgBullet.color = new Color(0.65f, 0.65f, 0.65f);
+            } else {
+                // 未選択
+                bulletSelectDetailList[i].imgBullet.color = new Color(1.0f, 1.0f, 1.0f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/BulletSelectManager.cs.meta
+++ b/Assets/Scripts/BulletSelectManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9ff59d57faf5e7439ad6bf6fbe0d67e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/DataBaseManager.cs
+++ b/Assets/Scripts/DataBaseManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 public class DataBaseManager : MonoBehaviour
 {
@@ -19,5 +20,37 @@ public class DataBaseManager : MonoBehaviour
         } else {
             Destroy(gameObject);
         }
+    }
+
+    /// <summary>
+    /// EnemyDataŽæ“¾—p
+    /// </summary>
+    /// <param name="enemyType"></param>
+    /// <returns></returns>
+    public EnemyDataSO.EnemyData GetEnemyData(EnemyDataSO.EnemyType enemyType) {
+        Debug.Log(enemyType);
+        foreach (EnemyDataSO.EnemyData enemyData in enemyDataSO.enemyDataList.Where(x => x.enemyType == enemyType)) {
+            return enemyData;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// BulletDataŽæ“¾—p
+    /// </summary>
+    /// <param name="enemyData"></param>
+    /// <returns></returns>
+    public BulletDataSO.BulletData GetEnemyBulletData(EnemyDataSO.EnemyData enemyData) {
+        foreach (BulletDataSO.BulletData bulletData in bulletDataSO.bulletDataList.Where((x) => x.bulletType == enemyData.bulletType)) {
+            return bulletData;
+        }
+        return null;
+    }
+
+    public BulletDataSO.BulletData GetPlayerBulletData(BulletDataSO.BulletType bulletType) {
+        foreach (BulletDataSO.BulletData bulletData in bulletDataSO.bulletDataList.Where((x) => x.bulletType == bulletType)) {
+            return bulletData;
+        }
+        return bulletDataSO.bulletDataList[0];
     }
 }

--- a/Assets/Scripts/EnemyGenerator.cs
+++ b/Assets/Scripts/EnemyGenerator.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using System.Linq;
 using DG.Tweening;
 
 public class EnemyGenerator : MonoBehaviour
@@ -72,14 +71,14 @@ public class EnemyGenerator : MonoBehaviour
     /// </summary>
     private void GenerateEnemy() {
         int randomEnemyNo = Random.Range(0, DataBaseManager.instance.enemyDataSO.enemyDataList.Count);
-        EnemyDataSO.EnemyData enemyData = GetEnemyData((EnemyDataSO.EnemyType)randomEnemyNo);
+        EnemyDataSO.EnemyData enemyData = DataBaseManager.instance.GetEnemyData((EnemyDataSO.EnemyType)randomEnemyNo);
 
         if (enemyData == null) {
             return;
         }
             
         EnemyController enemy = Instantiate(enemyPrefab, transform);
-        enemy.Inisialize(playerController, GetBulletData(enemyData), enemyData, enemyData.bulletType == BulletDataSO.BulletType.None ? null : bulletPrefab);
+        enemy.Inisialize(playerController, DataBaseManager.instance.GetEnemyBulletData(enemyData), enemyData, enemyData.bulletType == BulletDataSO.BulletType.None ? null : bulletPrefab);
         enemyList.Add(enemy);
 
         generateCount++;
@@ -117,9 +116,9 @@ public class EnemyGenerator : MonoBehaviour
 
         yield return StartCoroutine(DisplayAlert());
 
-        EnemyDataSO.EnemyData enemyData = GetEnemyData(EnemyDataSO.EnemyType.Boss);
+        EnemyDataSO.EnemyData enemyData = DataBaseManager.instance.GetEnemyData(EnemyDataSO.EnemyType.Boss);
         EnemyController enemy = Instantiate(enemyPrefab, transform);
-        enemy.Inisialize(playerController, GetBulletData(enemyData), enemyData, enemyData.bulletType == BulletDataSO.BulletType.None ? null : bulletPrefab);
+        enemy.Inisialize(playerController, DataBaseManager.instance.GetEnemyBulletData(enemyData), enemyData, enemyData.bulletType == BulletDataSO.BulletType.None ? null : bulletPrefab);
         enemy.InitializeBoss(this);
         enemyList.Add(enemy);
 
@@ -138,30 +137,5 @@ public class EnemyGenerator : MonoBehaviour
         canvasGroupBossAlert.DOFade(0.0f, 0.25f);
         yield return new WaitForSeconds(0.25f);
         canvasGroupBossAlert.transform.parent.gameObject.SetActive(false);
-    }
-
-    /// <summary>
-    /// EnemyDataŽæ“¾—p
-    /// </summary>
-    /// <param name="enemyType"></param>
-    /// <returns></returns>
-    private EnemyDataSO.EnemyData GetEnemyData(EnemyDataSO.EnemyType enemyType) {
-        Debug.Log(enemyType);
-        foreach (EnemyDataSO.EnemyData enemyData in DataBaseManager.instance.enemyDataSO.enemyDataList.Where(x => x.enemyType == enemyType)) {
-            return enemyData;
-        }
-        return null;
-    }
-
-    /// <summary>
-    /// BulletDataŽæ“¾—p
-    /// </summary>
-    /// <param name="enemyData"></param>
-    /// <returns></returns>
-    private BulletDataSO.BulletData GetBulletData(EnemyDataSO.EnemyData enemyData) {
-        foreach (BulletDataSO.BulletData bulletData in DataBaseManager.instance.bulletDataSO.bulletDataList.Where((x) => x.bulletType == enemyData.bulletType)) {
-            return bulletData;
-        }
-        return null;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,6 +7,11 @@ public class GameManager : MonoBehaviour
     [SerializeField]
     private EnemyGenerator enemyGenerator;
 
+    [SerializeField]
+    private BulletSelectManager bulletSelectManager;
+
+    [SerializeField]
+    private PlayerController playerController;
 
     private bool isSetUpEnd;
 
@@ -16,8 +21,10 @@ public class GameManager : MonoBehaviour
 
     public int maxWaveCount;
 
-    void Start()
+    IEnumerator Start()
     {
+        yield return StartCoroutine(bulletSelectManager.GenerateBulletSelectDetail(playerController));
+
         StartCoroutine(ObservateGenerateEnemyState());
     }
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -12,9 +12,12 @@ public class PlayerController : MonoBehaviour
 
     private GameManager gameManager;
 
+    public BulletDataSO.BulletType currentBulletType;
+
     void Start()
     {
         gameManager = GameObject.FindGameObjectWithTag("GameController").GetComponent<GameManager>();
+        bulletData = DataBaseManager.instance.GetPlayerBulletData(currentBulletType);
     }
 
 
@@ -37,5 +40,15 @@ public class PlayerController : MonoBehaviour
                 Debug.Log("バースト状態");
             }
         }    
+    }
+
+    /// <summary>
+    /// 弾を変更
+    /// </summary>
+    /// <param name="newBulletType"></param>
+    public void ChangeBullet(BulletDataSO.BulletType newBulletType) {
+        currentBulletType = newBulletType;
+
+        bulletData = DataBaseManager.instance.GetPlayerBulletData(currentBulletType);
     }
 }


### PR DESCRIPTION
・弾の種類の選択ウインドウを画面の下部にUIとして追加。
・ゲーム開始時にプレイヤー用の弾を選択するためのボタン群を画面の下部の弾の選択ウインドウ内に１つずつ順番に生成。
・ボタンの生成中は他の処理を止める制御を追加。
・選択ボタンを押すとプレイヤー用の発射する弾の種類が変更になる制御を追加。弾のデータはBulletDataSOを参照。
・プレイヤーの初期弾を設定。プレイヤーの弾のみサイズと回転方向を変更。
・エネミー側もBulletDataSOを参照。
・選択されている弾のボタンと選択されていない弾のボタンの色を変更して、現在の弾を見分けられるようにボタンを制御。
・デバッグ完了。