### PR TITLE
バレット選択ボタンの制御を修正

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1091,6 +1091,36 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 831663978}
   m_CullTransparentMesh: 1
+--- !u!1 &907989829
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 907989830}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &907989830
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 907989829}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.0852282, y: -1.7707131, z: 1479.3359}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &914820718
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BulletSelectDetail.cs
+++ b/Assets/Scripts/BulletSelectDetail.cs
@@ -32,6 +32,8 @@ public class BulletSelectDetail : MonoBehaviour
     [SerializeField]
     private Text txtOpenExpValue;
 
+    private bool isCostPayment;        // 現在コストを支払って開放済かどうか。trueならコスト支払い終了
+
     /// <summary>
     /// 初期設定
     /// </summary>
@@ -82,11 +84,16 @@ public class BulletSelectDetail : MonoBehaviour
             // ゲージを最大値にする
             imgLaunchTimeGauge.fillAmount = 1.0f;
 
+            // コスト支払い済状態にする = 開放条件にてEXPが足りなくても押せない状態にならないようにする
+            SetStateBulletCostPayment(true);
+
+            Debug.Log(GetStateBulletCostPayment());
+
             // EXP減算
             bulletSelectManager.UpdateTotalExp(-bulletData.openExp);
 
-            // EXP非表示
-            txtOpenExpValue.enabled = false;
+            // コストEXP非表示
+            txtOpenExpValue.enabled = false;            
         }
     }
 
@@ -154,5 +161,27 @@ public class BulletSelectDetail : MonoBehaviour
 
         // 開放に必要なEXPを表示
         txtOpenExpValue.enabled = true;
+
+        // コスト未払いの状態に戻す
+        SetStateBulletCostPayment(false);
+
+        // 
+        bulletSelectManager.JugdeOpenBullets();
+    }
+
+    /// <summary>
+    /// コスト支払い状態の確認
+    /// </summary>
+    /// <returns></returns>
+    public bool GetStateBulletCostPayment() {
+        return isCostPayment;
+    }
+
+    /// <summary>
+    /// コスト支払い状態の更新
+    /// </summary>
+    /// <param name="isSet"></param>
+    public void SetStateBulletCostPayment(bool isSet) {
+        isCostPayment = isSet;
     }
 }

--- a/Assets/Scripts/BulletSelectManager.cs
+++ b/Assets/Scripts/BulletSelectManager.cs
@@ -98,6 +98,12 @@ public class BulletSelectManager : MonoBehaviour
 
         // バレットごとに使用可能なEXPを超えているか確認
         foreach (BulletSelectDetail bulletData in bulletSelectDetailList) {
+            Debug.Log(bulletData.GetStateBulletCostPayment());
+            // コストを支払っているかどうか
+            if (bulletData.GetStateBulletCostPayment()) {
+                return;
+            }
+
             if (bulletData.bulletData.openExp <= totalExp) {
                 // 超えているものはタップできるようにする
                 bulletData.SwitchActivateBulletBtn(true);
@@ -128,5 +134,22 @@ public class BulletSelectManager : MonoBehaviour
     private void CreateFlotingExp(int exp) {
         FloatingMessage floatingDamage = Instantiate(floatingDamagePrefab, txtTotalExp.transform, false);
         floatingDamage.DisplayFloatingDamage(exp, FloatingMessage.FloatingMessageType.GetExp);
+    }
+
+    /// <summary>
+    /// すべてのバレットボタンの操作を押せないように制御
+    /// </summary>
+    public void InactivateAllBulletBtns() {
+        for (int i = 0; i < bulletSelectDetailList.Count; i++) {
+            bulletSelectDetailList[i].SwitchActivateBulletBtn(false);
+        }
+    }
+
+    /// <summary>
+    /// TotalExpを取得
+    /// </summary>
+    /// <returns></returns>
+    public int GetTotalExp() {
+        return totalExp;
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -88,6 +88,9 @@ public class GameManager : MonoBehaviour
 
         // クリア表示
         DisplayGameClear();
+
+        // すべてのバレットを押せない状態にする
+        bulletSelectManager.InactivateAllBulletBtns();
     }
 
     /// <summary>


### PR DESCRIPTION
・バレット選択ボタンに追加の制御を実装。
・コスト支払い状態の追加。支払い済状態のバレットについては、現在のEXPの値に関わらず、発射時間までは切り替えが出来るように制御追加。
・ゲームクリア、ゲームオーバー時にバレットを押せないように制御を追加。
・デバッグ時にバレット選択に関連する挙動に不具合があったので修正。