### PR TITLE
バレットの種類に応じた弾道を生成する制御を追加

### DIFF
--- a/Assets/Prefabs/FloatingMessageObj.prefab
+++ b/Assets/Prefabs/FloatingMessageObj.prefab
@@ -68,7 +68,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_Font: {fileID: 12800000, guid: b22eec4abb040604ca5b07afd2348916, type: 3}
     m_FontSize: 80
     m_FontStyle: 1
     m_BestFit: 0

--- a/Assets/Prefabs/btnBulletSelect.prefab
+++ b/Assets/Prefabs/btnBulletSelect.prefab
@@ -169,7 +169,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
-    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -368,7 +367,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_Font: {fileID: 12800000, guid: b22eec4abb040604ca5b07afd2348916, type: 3}
     m_FontSize: 120
     m_FontStyle: 0
     m_BestFit: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1206,36 +1206,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 831663978}
   m_CullTransparentMesh: 1
---- !u!1 &907989829
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 907989830}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &907989830
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 907989829}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.0852282, y: -1.7707131, z: 1479.3359}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &914820718
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -711,6 +711,36 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &317413092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 317413093}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &317413093
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 317413092}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 8545.6045, y: 32181.396, z: 90}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &404833954
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -11,7 +11,36 @@ public class Bullet : MonoBehaviour {
     [SerializeField]
     private Image imgBullet;
 
+    bool isTarget;
+
+    Vector3 Position;
+
+    float rad;
+
+    public Vector3 nearPos;
+
+    Vector3 dir;
+
     public void Shot(BulletDataSO.BulletData bulletData, Vector3 direction) {
+
+        nearPos = Vector3.zero;
+        if (bulletData.bulletType == BulletDataSO.BulletType.E) {
+            GameObject[] enemies = GameObject.FindGameObjectsWithTag("Enemy");
+            if (enemies.Length > 0) {
+                nearPos = enemies[0].transform.position;
+                Vector3 myPos = transform.position;
+                for (int i = 0; i < enemies.Length; i++) {
+                    Vector3 pos = enemies[i].transform.position - myPos;
+
+                    if (nearPos.x < pos.x && nearPos.y < pos.y) {
+                        nearPos = pos;
+                    }
+                }
+            }
+            Debug.Log(nearPos);
+            isTarget = true;
+        }
+
         this.bulletData = bulletData;
         imgBullet.sprite = bulletData.sprite;
 
@@ -19,6 +48,37 @@ public class Bullet : MonoBehaviour {
             transform.eulerAngles = new Vector3(0, 0, 180);
             transform.localScale = new Vector3(2, 2, 2);
         }
-        GetComponent<Rigidbody2D>().AddForce(direction * bulletData.bulletSpeed);
+
+        if (bulletData.bulletType != BulletDataSO.BulletType.E) {
+            GetComponent<Rigidbody2D>().AddForce(direction * bulletData.bulletSpeed);
+        } else {
+            dir = Vector3.Scale(nearPos - transform.position, new Vector3(1, 1, 0)).normalized;
+            rad = Mathf.Atan2(dir.y, dir.x);
+
+            Debug.Log(rad);
+        }
+
+        Destroy(gameObject, 5.0f);
+    }
+
+    private void Update() {
+        if (!isTarget) {
+            return;
+        }
+
+        Vector3 currentPos = transform.position;
+        Vector3 targetPos = nearPos;
+
+        transform.position = Vector3.MoveTowards(currentPos, targetPos, Time.deltaTime * bulletData.bulletSpeed);
+
+        //// 現在位置をPositionに代入
+        //Position = transform.localPosition;
+        //// x += SPEED * cos(ラジアン)
+        //// y += SPEED * sin(ラジアン)
+        //// これで特定の方向へ向かって進んでいく。
+        //Position.x += bulletData.bulletSpeed * Mathf.Cos(rad);
+        //Position.y += bulletData.bulletSpeed * Mathf.Sin(rad);
+        //// 現在の位置に加算減算を行ったPositionを代入する
+        //transform.localPosition = Position;
     }
 }

--- a/Assets/Scripts/BulletSelectManager.cs
+++ b/Assets/Scripts/BulletSelectManager.cs
@@ -101,7 +101,8 @@ public class BulletSelectManager : MonoBehaviour
             Debug.Log(bulletData.GetStateBulletCostPayment());
             // ƒRƒXƒg‚ðŽx•¥‚Á‚Ä‚¢‚é‚©‚Ç‚¤‚©
             if (bulletData.GetStateBulletCostPayment()) {
-                return;
+                bulletData.SwitchActivateBulletBtn(true);
+                continue;
             }
 
             if (bulletData.bulletData.openExp <= totalExp) {
@@ -151,5 +152,12 @@ public class BulletSelectManager : MonoBehaviour
     /// <returns></returns>
     public int GetTotalExp() {
         return totalExp;
+    }
+
+    public void AllSwitchActivateBulletBtn(bool isSwitch) {
+        for (int i = 0; i < bulletSelectDetailList.Count; i++) {
+            // ‰Ÿ‚¹‚È‚¢ó‘Ô‚É‚·‚é
+            bulletSelectDetailList[i].SwitchActivateBulletBtn(isSwitch);
+        }
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -35,18 +35,22 @@ public class PlayerController : MonoBehaviour
         }
 
         if (Input.GetMouseButtonDown(0)) {
+            // 画面をタップ(クリック)した位置をカメラのスクリーン座標の情報を通じてワールド座標に変換
             Vector3 tapPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
 
-            // 向きの生成（Z成分の除去と正規化）
+            // 向きの生成(Z成分の除去と正規化)
             Vector3 direction = Vector3.Scale(tapPos - transform.position, new Vector3(1, 1, 0)).normalized;
 
-            Instantiate(bulletPrefab, transform).Shot(bulletData, direction);
+            //Debug.Log(direction);
 
-            tapCount++;
-
-            if (tapCount >= 50) {
-                Debug.Log("バースト状態");
+            // キャラの位置よりも下方向に向きがある場合(キャラの位置よりも下にある画面をタップした場合)
+            if (direction.y <= 0.0f) {
+                // 生成処理しない
+                return;
             }
+
+            // バレット生成
+            GenerateBullet(direction);
         }    
     }
 
@@ -58,5 +62,36 @@ public class PlayerController : MonoBehaviour
         currentBulletType = newBulletType;
 
         bulletData = DataBaseManager.instance.GetPlayerBulletData(currentBulletType);
+    }
+
+    private void GenerateBullet(Vector3 direction) {
+        switch (bulletData.bulletType) {
+            case BulletDataSO.BulletType.D:
+                Instantiate(bulletPrefab, transform).Shot(bulletData, direction);
+                break;
+            case BulletDataSO.BulletType.E:
+                Instantiate(bulletPrefab, transform).Shot(bulletData, direction);
+                break;
+            case BulletDataSO.BulletType.F:
+                Instantiate(bulletPrefab, transform).Shot(bulletData, new Vector3(direction.x -0.5f, direction.y, direction.z));
+                Instantiate(bulletPrefab, transform).Shot(bulletData, direction);
+                Instantiate(bulletPrefab, transform).Shot(bulletData, new Vector3(direction.x + 0.5f, direction.y, direction.z));
+                break;
+            case BulletDataSO.BulletType.G:
+                Instantiate(bulletPrefab, transform).Shot(bulletData, new Vector3(direction.x - 0.5f, direction.y, direction.z));
+                Instantiate(bulletPrefab, transform).Shot(bulletData, new Vector3(direction.x - 0.25f, direction.y, direction.z));
+                Instantiate(bulletPrefab, transform).Shot(bulletData, direction);
+                Instantiate(bulletPrefab, transform).Shot(bulletData, new Vector3(direction.x + 0.25f, direction.y, direction.z));
+                Instantiate(bulletPrefab, transform).Shot(bulletData, new Vector3(direction.x + 0.5f, direction.y, direction.z));
+                break;
+        }
+
+
+
+        tapCount++;
+
+        if (tapCount >= 50) {
+            Debug.Log("バースト状態");
+        }
     }
 }


### PR DESCRIPTION
・バレットの種類に応じて４種類の弾道を追加。スクリプタブル・オブジェクトのデータと同期。
・バレットのボタンに合わせて生成処理を制御。
・バレットのボタンの挙動に一部不具合があったので修正。
・画面のフッター部分をタップした際にはバレットを生成しない制御を追加。
・バレットボタン上のコスト表示のフォントを変更。
・デバッグ完了。